### PR TITLE
Add Stream Cipher and other minor improvements

### DIFF
--- a/lib/aes/aes.ex
+++ b/lib/aes/aes.ex
@@ -1,13 +1,14 @@
 defmodule ExCrypto.AES do
   @moduledoc """
-  Defines standard functions for use with AES symmetric cryptography.
+  Defines standard functions for use with AES symmetric cryptography in block mode.
   """
 
-  @cipher_type :aes_cbc
+  @type mode :: :cbc | :ctr
+
   @block_size 32
 
   @doc """
-  Returns the blocksize for AES encryption.
+  Returns the blocksize for AES encryption when used as block mode encryption.
 
   ## Examples
 
@@ -18,30 +19,57 @@ defmodule ExCrypto.AES do
   def block_size, do: @block_size
 
   @doc """
-  Encrypts a given binary with the given public key.
+  Encrypts a given binary with the given public key. For block mode, this is the
+  standard encrypt operation. For streaming mode, this will return the final block
+  of the stream.
+
+  Note: for streaming modes, `init_vector` is the same as ICB.
 
   ## Examples
 
-      iex> ExCrypto.AES.encrypt("obi wan", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      iex> ExCrypto.AES.encrypt("obi wan", :cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
       <<86, 16, 7, 47, 97, 219, 8, 46, 16, 170, 70, 100, 131, 140, 241, 28>>
 
-      iex> ExCrypto.AES.encrypt("obi wan", ExCrypto.Test.symmetric_key(:key_b), ExCrypto.Test.init_vector)
+      iex> ExCrypto.AES.encrypt("obi wan", :cbc, ExCrypto.Test.symmetric_key(:key_b), ExCrypto.Test.init_vector)
       <<219, 181, 173, 235, 88, 139, 229, 61, 172, 142, 36, 195, 83, 203, 237, 39>>
 
-      iex> ExCrypto.AES.encrypt("obi wan", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector(2))
+      iex> ExCrypto.AES.encrypt("obi wan", :cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector(2))
       <<134, 126, 59, 64, 83, 197, 85, 40, 155, 178, 52, 165, 27, 190, 60, 170>>
 
-      iex> ExCrypto.AES.encrypt("jedi knight", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      iex> ExCrypto.AES.encrypt("jedi knight", :cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
       <<54, 252, 188, 111, 221, 182, 65, 54, 77, 143, 127, 188, 176, 178, 50, 160>>
 
-      iex> ExCrypto.AES.encrypt("Did you ever hear the story of Darth Plagueis The Wise? I thought not.", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector) |> ExCrypto.Math.bin_to_hex
+      iex> ExCrypto.AES.encrypt("Did you ever hear the story of Darth Plagueis The Wise? I thought not.", :cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector) |> ExCrypto.Math.bin_to_hex
       "3ee326e03303a303df6eac828b0bdc8ed67254b44a6a79cd0082bc245977b0e7d4283d63a346744d2f1ecaafca8be906d9f3d27db914d80b601d7e0c598418380e5fe2b48c0e0b8454c6d251f577f28f"
+
+      iex> ExCrypto.AES.encrypt("obi wan", :ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      <<32, 99, 57, 7, 64, 82, 28>>
+
+      iex> ExCrypto.AES.encrypt("obi wan", :ctr, ExCrypto.Test.symmetric_key(:key_b), ExCrypto.Test.init_vector)
+      <<156, 176, 33, 64, 69, 16, 173>>
+
+      iex> ExCrypto.AES.encrypt("obi wan", :ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector(2))
+      <<214, 99, 7, 241, 219, 189, 178>>
+
+      iex> ExCrypto.AES.encrypt("jedi knight", :ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      <<37, 100, 52, 78, 23, 88, 28, 22, 254, 47, 32>>
+
+      iex> ExCrypto.AES.encrypt("Did you ever hear the story of Darth Plagueis The Wise? I thought not.", :ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector) |> ExCrypto.Math.bin_to_hex
+      "0b6834074e5c075ffc31318cc03cba1fe35648a6f149a74952661473b73570fb98332e31870c111d3ae5ccff2154bd4083a7ee4bfd19bc85eba77835aac4cea881ada2630cdd"
   """
-  @spec encrypt(ExCrypto.Cipher.plaintext, ExCrypto.symmetric_key, ExCrypto.Cipher.init_vector) :: ExCrypto.Cipher.ciphertext
-  def encrypt(plaintext, symmetric_key, init_vector) do
+  @spec encrypt(ExCrypto.Cipher.plaintext, mode, ExCrypto.symmetric_key, ExCrypto.Cipher.init_vector) :: ExCrypto.Cipher.ciphertext
+  def encrypt(plaintext, :cbc, symmetric_key, init_vector) do
     padding_bits = ( 16 - rem(byte_size(plaintext), 16) ) * 8
 
-    :crypto.block_encrypt(@cipher_type, symmetric_key, init_vector, <<0::size(padding_bits)>> <> plaintext)
+    :crypto.block_encrypt(:aes_cbc, symmetric_key, init_vector, <<0::size(padding_bits)>> <> plaintext)
+  end
+
+  def encrypt(plaintext, :ctr, symmetric_key, init_vector) do
+    {_state, ciphertext} =
+      :crypto.stream_init(:aes_ctr, symmetric_key, init_vector)
+      |> :crypto.stream_encrypt(plaintext)
+
+    ciphertext
   end
 
   @doc """
@@ -50,28 +78,57 @@ defmodule ExCrypto.AES do
   ## Examples
 
       iex> <<86, 16, 7, 47, 97, 219, 8, 46, 16, 170, 70, 100, 131, 140, 241, 28>>
-      ...> |> ExCrypto.AES.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      ...> |> ExCrypto.AES.decrypt(:cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
       <<0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "obi wan"
 
       iex> <<219, 181, 173, 235, 88, 139, 229, 61, 172, 142, 36, 195, 83, 203, 237, 39>>
-      ...> |> ExCrypto.AES.decrypt(ExCrypto.Test.symmetric_key(:key_b), ExCrypto.Test.init_vector)
+      ...> |> ExCrypto.AES.decrypt(:cbc, ExCrypto.Test.symmetric_key(:key_b), ExCrypto.Test.init_vector)
       <<0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "obi wan"
 
       iex> <<134, 126, 59, 64, 83, 197, 85, 40, 155, 178, 52, 165, 27, 190, 60, 170>>
-      ...> |> ExCrypto.AES.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector(2))
+      ...> |> ExCrypto.AES.decrypt(:cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector(2))
       <<0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "obi wan"
 
       iex> <<54, 252, 188, 111, 221, 182, 65, 54, 77, 143, 127, 188, 176, 178, 50, 160>>
-      ...> |> ExCrypto.AES.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      ...> |> ExCrypto.AES.decrypt(:cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
       <<0, 0, 0, 0, 0>> <> "jedi knight"
 
       iex> "3ee326e03303a303df6eac828b0bdc8ed67254b44a6a79cd0082bc245977b0e7d4283d63a346744d2f1ecaafca8be906d9f3d27db914d80b601d7e0c598418380e5fe2b48c0e0b8454c6d251f577f28f"
       ...> |> ExCrypto.Math.hex_to_bin
-      ...> |> ExCrypto.AES.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      ...> |> ExCrypto.AES.decrypt(:cbc, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
       <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "Did you ever hear the story of Darth Plagueis The Wise? I thought not."
+
+      iex> <<32, 99, 57, 7, 64, 82, 28>>
+      ...> |> ExCrypto.AES.decrypt(:ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      "obi wan"
+
+      iex> <<156, 176, 33, 64, 69, 16, 173>>
+      ...> |> ExCrypto.AES.decrypt(:ctr, ExCrypto.Test.symmetric_key(:key_b), ExCrypto.Test.init_vector)
+      "obi wan"
+
+      iex> <<214, 99, 7, 241, 219, 189, 178>>
+      ...> |> ExCrypto.AES.decrypt(:ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector(2))
+      "obi wan"
+
+      iex> <<37, 100, 52, 78, 23, 88, 28, 22, 254, 47, 32>>
+      ...> |> ExCrypto.AES.decrypt(:ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      "jedi knight"
+
+      iex> "0b6834074e5c075ffc31318cc03cba1fe35648a6f149a74952661473b73570fb98332e31870c111d3ae5ccff2154bd4083a7ee4bfd19bc85eba77835aac4cea881ada2630cdd"
+      ...> |> ExCrypto.Math.hex_to_bin
+      ...> |> ExCrypto.AES.decrypt(:ctr, ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector)
+      "Did you ever hear the story of Darth Plagueis The Wise? I thought not."
   """
-  @spec decrypt(ExCrypto.Cipher.ciphertext, ExCrypto.symmetric_key, ExCrypto.Cipher.init_vector) :: ExCrypto.Cipher.plaintext
-  def decrypt(ciphertext, symmetric_key, init_vector) do
-    :crypto.block_decrypt(@cipher_type, symmetric_key, init_vector, ciphertext)
+  @spec decrypt(ExCrypto.Cipher.ciphertext, mode, ExCrypto.symmetric_key, ExCrypto.Cipher.init_vector) :: ExCrypto.Cipher.plaintext
+  def decrypt(ciphertext, :cbc, symmetric_key, init_vector) do
+    :crypto.block_decrypt(:aes_cbc, symmetric_key, init_vector, ciphertext)
+  end
+
+  def decrypt(ciphertext, :ctr, symmetric_key, init_vector) do
+    {_state, plaintext} =
+      :crypto.stream_init(:aes_ctr, symmetric_key, init_vector)
+      |> :crypto.stream_decrypt(ciphertext)
+
+    plaintext
   end
 end

--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -13,12 +13,15 @@ defmodule ExCrypto.Cipher do
 
   ## Examples
 
-      iex> ExCrypto.Cipher.encrypt("execute order 66", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector, {ExCrypto.AES, ExCrypto.AES.block_size}) |> ExCrypto.Math.bin_to_hex
+      iex> ExCrypto.Cipher.encrypt("execute order 66", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector, {ExCrypto.AES, ExCrypto.AES.block_size, :cbc}) |> ExCrypto.Math.bin_to_hex
       "4f0150273733727f994754fee054df7e18ec169892db5ba973cf8580b898651b"
+
+      iex> ExCrypto.Cipher.encrypt("execute order 66", ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector, {ExCrypto.AES, ExCrypto.AES.block_size, :ctr}) |> ExCrypto.Math.bin_to_hex
+      "2a7935444247175ff635309b9274e948"
   """
   @spec encrypt(plaintext, ExCrypto.symmetric_key, init_vector, cipher) :: ciphertext
-  def encrypt(plaintext, symmetric_key, init_vector, {mod, _block_size} = _cipher) do
-    mod.encrypt(plaintext, symmetric_key, init_vector)
+  def encrypt(plaintext, symmetric_key, init_vector, {mod, _block_size, mode} = _cipher) do
+    mod.encrypt(plaintext, mode, symmetric_key, init_vector)
   end
 
   @doc """
@@ -28,12 +31,17 @@ defmodule ExCrypto.Cipher do
 
       iex> "4f0150273733727f994754fee054df7e18ec169892db5ba973cf8580b898651b"
       ...> |> ExCrypto.Math.hex_to_bin
-      ...> |> ExCrypto.Cipher.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector, {ExCrypto.AES, ExCrypto.AES.block_size})
+      ...> |> ExCrypto.Cipher.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector, {ExCrypto.AES, ExCrypto.AES.block_size, :cbc})
       <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "execute order 66"
+
+      iex> "2a7935444247175ff635309b9274e948"
+      ...> |> ExCrypto.Math.hex_to_bin
+      ...> |> ExCrypto.Cipher.decrypt(ExCrypto.Test.symmetric_key, ExCrypto.Test.init_vector, {ExCrypto.AES, ExCrypto.AES.block_size, :ctr})
+      "execute order 66"
   """
   @spec decrypt(ciphertext, ExCrypto.symmetric_key, init_vector, cipher) :: plaintext
-  def decrypt(ciphertext, symmetric_key, init_vector, {mod, _block_size} = _cipher) do
-    mod.decrypt(ciphertext, symmetric_key, init_vector)
+  def decrypt(ciphertext, symmetric_key, init_vector, {mod, _block_size, mode} = _cipher) do
+    mod.decrypt(ciphertext, mode, symmetric_key, init_vector)
   end
 
   @doc """

--- a/lib/ecies/parameters.ex
+++ b/lib/ecies/parameters.ex
@@ -31,7 +31,7 @@ defmodule ExCrypto.ECIES.Parameters do
     %__MODULE__{
       mac: :sha256,
       hasher: {&ExCrypto.Hash.SHA.sha256/1, nil, 32},
-      cipher: {ExCrypto.AES, ExCrypto.AES.block_size},
+      cipher: {ExCrypto.AES, ExCrypto.AES.block_size, :ctr},
       key_len: 16,
     }
   end
@@ -45,7 +45,7 @@ defmodule ExCrypto.ECIES.Parameters do
     %__MODULE__{
       mac: :sha256,
       hasher: {&ExCrypto.Hash.SHA.sha256/1, nil, 32},
-      cipher: {ExCrypto.AES, ExCrypto.AES.block_size},
+      cipher: {ExCrypto.AES, ExCrypto.AES.block_size, :ctr},
       key_len: 32,
     }
   end
@@ -59,7 +59,7 @@ defmodule ExCrypto.ECIES.Parameters do
     %__MODULE__{
       mac: :sha256,
       hasher: {&ExCrypto.Hash.SHA.sha384/1, nil, 48},
-      cipher: {ExCrypto.AES, ExCrypto.AES.block_size},
+      cipher: {ExCrypto.AES, ExCrypto.AES.block_size, :ctr},
       key_len: 32,
     }
   end
@@ -73,7 +73,7 @@ defmodule ExCrypto.ECIES.Parameters do
     %__MODULE__{
       mac: :sha256,
       hasher: {&ExCrypto.Hash.SHA.sha512/1, nil, 64},
-      cipher: {ExCrypto.AES, ExCrypto.AES.block_size},
+      cipher: {ExCrypto.AES, ExCrypto.AES.block_size, :ctr},
       key_len: 32,
     }
   end
@@ -88,7 +88,7 @@ defmodule ExCrypto.ECIES.Parameters do
   """
   @spec block_size(t) :: integer()
   def block_size(params) do
-    {_, block_size} = params.cipher
+    {_, block_size, _args} = params.cipher
 
     block_size
   end

--- a/lib/math/math.ex
+++ b/lib/math/math.ex
@@ -50,4 +50,20 @@ defmodule ExCrypto.Math do
   @spec bin_to_hex(binary()) :: String.t
   def bin_to_hex(bin), do: Base.encode16(bin, case: :lower)
 
+  @doc """
+  Generate a random nonce value of specified length.
+
+  ## Examples
+
+      iex> ExCrypto.Math.nonce(32) |> byte_size
+      32
+
+      iex> ExCrypto.Math.nonce(32) == ExCrypto.Math.nonce(32)
+      false
+  """
+  @spec nonce(integer()) :: binary()
+  def nonce(nonce_size) do
+    :crypto.strong_rand_bytes(nonce_size)
+  end
+
 end


### PR DESCRIPTION
This patch adds the Stream Cipher for AES, which is used in RLPx's handshake protocol. We also opt to store public keys in a raw format, instead of starting with a 0x04 byte indicating an octet_string in DER format. This distinction is always confusing, but messed up our encoding and packet size.