### PR TITLE
[WIP] Add streaming modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+* 0.1.4
+* Add MAC stream.
+* Improve signature recovery algorithms
+* Add ECB mode for AES
 # 0.1.3
 * Adds additional test keys pairs and `key_pair` as a type.
 # 0.1.2

--- a/lib/aes/aes.ex
+++ b/lib/aes/aes.ex
@@ -160,6 +160,7 @@ defmodule ExthCrypto.AES do
   """
   @spec stream_init(ExthCrypto.Cipher.mode, ExthCrypto.Key.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.stream
   def stream_init(:ctr, symmetric_key, init_vector) do
+    # IO.inspect(["Have symm key: ", symmetric_key])
     :crypto.stream_init(:aes_ctr, symmetric_key, init_vector)
   end
 

--- a/lib/aes/aes.ex
+++ b/lib/aes/aes.ex
@@ -3,8 +3,6 @@ defmodule ExthCrypto.AES do
   Defines standard functions for use with AES symmetric cryptography in block mode.
   """
 
-  @type mode :: :cbc | :ctr | :ecb
-
   @block_size 32
 
   @doc """
@@ -60,7 +58,7 @@ defmodule ExthCrypto.AES do
       iex> ExthCrypto.AES.encrypt("jedi knight", :ecb, ExthCrypto.Test.symmetric_key)
       <<98, 60, 215, 107, 189, 132, 176, 63, 62, 225, 92, 13, 70, 53, 187, 240>>
   """
-  @spec encrypt(ExthCrypto.Cipher.plaintext, mode, ExthCrypto.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.ciphertext
+  @spec encrypt(ExthCrypto.Cipher.plaintext, ExthCrypto.Cipher.mode, ExthCrypto.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.ciphertext
   def encrypt(plaintext, :cbc, symmetric_key, init_vector) do
     padding_bits = ( 16 - rem(byte_size(plaintext), 16) ) * 8
 
@@ -75,7 +73,7 @@ defmodule ExthCrypto.AES do
     ciphertext
   end
 
-  @spec encrypt(ExthCrypto.Cipher.plaintext, mode, ExthCrypto.symmetric_key) :: ExthCrypto.Cipher.ciphertext
+  @spec encrypt(ExthCrypto.Cipher.plaintext, ExthCrypto.Cipher.mode, ExthCrypto.symmetric_key) :: ExthCrypto.Cipher.ciphertext
   def encrypt(plaintext, :ecb, symmetric_key) do
     padding_bits = ( 16 - rem(byte_size(plaintext), 16) ) * 8
 
@@ -132,7 +130,7 @@ defmodule ExthCrypto.AES do
       iex> ExthCrypto.AES.decrypt(<<98, 60, 215, 107, 189, 132, 176, 63, 62, 225, 92, 13, 70, 53, 187, 240>>, :ecb, ExthCrypto.Test.symmetric_key)
       <<0, 0, 0, 0, 0>> <> "jedi knight"
   """
-  @spec decrypt(ExthCrypto.Cipher.ciphertext, mode, ExthCrypto.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.plaintext
+  @spec decrypt(ExthCrypto.Cipher.ciphertext, ExthCrypto.Cipher.mode, ExthCrypto.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.plaintext
   def decrypt(ciphertext, :cbc, symmetric_key, init_vector) do
     :crypto.block_decrypt(:aes_cbc, symmetric_key, init_vector, ciphertext)
   end
@@ -145,7 +143,7 @@ defmodule ExthCrypto.AES do
     plaintext
   end
 
-  @spec decrypt(ExthCrypto.Cipher.ciphertext, mode, ExthCrypto.symmetric_key) :: ExthCrypto.Cipher.plaintext
+  @spec decrypt(ExthCrypto.Cipher.ciphertext, ExthCrypto.Cipher.mode, ExthCrypto.symmetric_key) :: ExthCrypto.Cipher.plaintext
   def decrypt(ciphertext, :ecb, symmetric_key) do
     :crypto.block_decrypt(:aes_ecb, symmetric_key, ciphertext)
   end
@@ -160,7 +158,7 @@ defmodule ExthCrypto.AES do
       iex> is_nil(stream)
       false
   """
-  @spec stream_init(mode, ExthCrypto.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.stream
+  @spec stream_init(ExthCrypto.Cipher.mode, ExthCrypto.Key.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.stream
   def stream_init(:ctr, symmetric_key, init_vector) do
     :crypto.stream_init(:aes_ctr, symmetric_key, init_vector)
   end

--- a/lib/aes/aes.ex
+++ b/lib/aes/aes.ex
@@ -131,4 +131,53 @@ defmodule ExthCrypto.AES do
 
     plaintext
   end
+
+  @doc """
+  Initializes an AES stream in the given mode with a given
+  key and init vector.
+
+  ## Examples
+
+      iex> stream = ExthCrypto.AES.stream_init(:ctr, ExthCrypto.Test.symmetric_key(), ExthCrypto.Test.init_vector)
+      iex> is_nil(stream)
+      false
+  """
+  @spec stream_init(mode, ExthCrypto.symmetric_key, ExthCrypto.Cipher.init_vector) :: ExthCrypto.Cipher.stream
+  def stream_init(:ctr, symmetric_key, init_vector) do
+    :crypto.stream_init(:aes_ctr, symmetric_key, init_vector)
+  end
+
+  @doc """
+  Encrypts data with an already initialized AES stream, returning a
+  stream with updated state, as well as the ciphertext.
+
+  ## Examples
+
+      iex> stream = ExthCrypto.AES.stream_init(:ctr, ExthCrypto.Test.symmetric_key(), ExthCrypto.Test.init_vector)
+      iex> {_stream_2, ciphertext} = ExthCrypto.AES.stream_encrypt("hello", stream)
+      iex> ciphertext
+      "'d<KX"
+  """
+  @spec stream_encrypt(ExthCrypto.Cipher.plaintext, ExthCrypto.Cipher.stream) :: { ExthCrypto.Cipher.stream, ExthCrypto.Cipher.ciphertext }
+  def stream_encrypt(plaintext, stream) do
+    :crypto.stream_encrypt(stream, plaintext)
+  end
+
+  @doc """
+  Decrypts data from an already initialized AES stream, returning a
+  stream with updated state, as well as the plaintext.
+
+  ## Examples
+
+      iex> stream = ExthCrypto.AES.stream_init(:ctr, ExthCrypto.Test.symmetric_key(), ExthCrypto.Test.init_vector)
+      iex> {_stream_2, ciphertext} = ExthCrypto.AES.stream_encrypt("hello", stream)
+      iex> {_stream_3, plaintext} = ExthCrypto.AES.stream_decrypt(ciphertext, stream)
+      iex> plaintext
+      "hello"
+  """
+  @spec stream_decrypt(ExthCrypto.Cipher.ciphertext, ExthCrypto.Cipher.stream) :: { ExthCrypto.Cipher.stream, ExthCrypto.Cipher.plaintrxt }
+  def stream_decrypt(plaintext, stream) do
+    :crypto.stream_decrypt(stream, plaintext)
+  end
+
 end

--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -7,6 +7,7 @@ defmodule ExthCrypto.Cipher do
   @type plaintext :: iodata()
   @type ciphertext :: binary()
   @type init_vector :: binary()
+  @opaque stream :: :crypto.ctr_state
 
   @doc """
   Encrypts the given plaintext for the given block cipher.

--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -3,7 +3,8 @@ defmodule ExthCrypto.Cipher do
   Module for symmetric encryption.
   """
 
-  @type cipher :: {atom(), integer()}
+  @type mode :: :cbc | :ctr | :ecb
+  @type cipher :: {atom(), integer(), mode}
   @type plaintext :: iodata()
   @type ciphertext :: binary()
   @type init_vector :: binary()
@@ -23,12 +24,12 @@ defmodule ExthCrypto.Cipher do
       iex> ExthCrypto.Cipher.encrypt("execute order 66", ExthCrypto.Test.symmetric_key, {ExthCrypto.AES, ExthCrypto.AES.block_size, :ecb}) |> ExthCrypto.Math.bin_to_hex
       "a73c5576667b7b43a23a9fd930b5465d637a44d08bf702881a8d4e6a5d4944b5"
   """
-  @spec encrypt(plaintext, ExthCrypto.symmetric_key, init_vector, cipher) :: ciphertext
+  @spec encrypt(plaintext, ExthCrypto.Key.symmetric_key, init_vector, cipher) :: ciphertext
   def encrypt(plaintext, symmetric_key, init_vector, {mod, _block_size, mode} = _cipher) do
     mod.encrypt(plaintext, mode, symmetric_key, init_vector)
   end
 
-  @spec encrypt(plaintext, ExthCrypto.symmetric_key, cipher) :: ciphertext
+  @spec encrypt(plaintext, ExthCrypto.Key.symmetric_key, cipher) :: ciphertext
   def encrypt(plaintext, symmetric_key, {mod, _block_size, mode} = _cipher) do
     mod.encrypt(plaintext, mode, symmetric_key)
   end
@@ -53,12 +54,12 @@ defmodule ExthCrypto.Cipher do
       ...> |> ExthCrypto.Cipher.decrypt(ExthCrypto.Test.symmetric_key, {ExthCrypto.AES, ExthCrypto.AES.block_size, :ecb})
       <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "execute order 66"
   """
-  @spec decrypt(ciphertext, ExthCrypto.symmetric_key, init_vector, cipher) :: plaintext
+  @spec decrypt(ciphertext, ExthCrypto.Key.symmetric_key, init_vector, cipher) :: plaintext
   def decrypt(ciphertext, symmetric_key, init_vector, {mod, _block_size, mode} = _cipher) do
     mod.decrypt(ciphertext, mode, symmetric_key, init_vector)
   end
 
-  @spec decrypt(ciphertext, ExthCrypto.symmetric_key, cipher) :: plaintext
+  @spec decrypt(ciphertext, ExthCrypto.Key.symmetric_key, cipher) :: plaintext
   def decrypt(ciphertext, symmetric_key, {mod, _block_size, mode} = _cipher) do
     mod.decrypt(ciphertext, mode, symmetric_key)
   end

--- a/lib/cipher.ex
+++ b/lib/cipher.ex
@@ -19,10 +19,18 @@ defmodule ExthCrypto.Cipher do
 
       iex> ExthCrypto.Cipher.encrypt("execute order 66", ExthCrypto.Test.symmetric_key, ExthCrypto.Test.init_vector, {ExthCrypto.AES, ExthCrypto.AES.block_size, :ctr}) |> ExthCrypto.Math.bin_to_hex
       "2a7935444247175ff635309b9274e948"
+
+      iex> ExthCrypto.Cipher.encrypt("execute order 66", ExthCrypto.Test.symmetric_key, {ExthCrypto.AES, ExthCrypto.AES.block_size, :ecb}) |> ExthCrypto.Math.bin_to_hex
+      "a73c5576667b7b43a23a9fd930b5465d637a44d08bf702881a8d4e6a5d4944b5"
   """
   @spec encrypt(plaintext, ExthCrypto.symmetric_key, init_vector, cipher) :: ciphertext
   def encrypt(plaintext, symmetric_key, init_vector, {mod, _block_size, mode} = _cipher) do
     mod.encrypt(plaintext, mode, symmetric_key, init_vector)
+  end
+
+  @spec encrypt(plaintext, ExthCrypto.symmetric_key, cipher) :: ciphertext
+  def encrypt(plaintext, symmetric_key, {mod, _block_size, mode} = _cipher) do
+    mod.encrypt(plaintext, mode, symmetric_key)
   end
 
   @doc """
@@ -39,10 +47,20 @@ defmodule ExthCrypto.Cipher do
       ...> |> ExthCrypto.Math.hex_to_bin
       ...> |> ExthCrypto.Cipher.decrypt(ExthCrypto.Test.symmetric_key, ExthCrypto.Test.init_vector, {ExthCrypto.AES, ExthCrypto.AES.block_size, :ctr})
       "execute order 66"
+
+      iex> "a73c5576667b7b43a23a9fd930b5465d637a44d08bf702881a8d4e6a5d4944b5"
+      ...> |> ExthCrypto.Math.hex_to_bin
+      ...> |> ExthCrypto.Cipher.decrypt(ExthCrypto.Test.symmetric_key, {ExthCrypto.AES, ExthCrypto.AES.block_size, :ecb})
+      <<0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0>> <> "execute order 66"
   """
   @spec decrypt(ciphertext, ExthCrypto.symmetric_key, init_vector, cipher) :: plaintext
   def decrypt(ciphertext, symmetric_key, init_vector, {mod, _block_size, mode} = _cipher) do
     mod.decrypt(ciphertext, mode, symmetric_key, init_vector)
+  end
+
+  @spec decrypt(ciphertext, ExthCrypto.symmetric_key, cipher) :: plaintext
+  def decrypt(ciphertext, symmetric_key, {mod, _block_size, mode} = _cipher) do
+    mod.decrypt(ciphertext, mode, symmetric_key)
   end
 
   @doc """

--- a/lib/ecies/ecies.ex
+++ b/lib/ecies/ecies.ex
@@ -40,7 +40,7 @@ defmodule ExthCrypto.ECIES do
   """
   @spec encrypt(ExthCrypto.Key.public_key, Cipher.plaintext, binary(), binary(), {ExthCrypto.Key.public_key, ExthCrypto.Key.private_key} | nil, Cipher.init_vector | nil) :: {:ok, binary()} | {:error, String.t}
   def encrypt(her_static_public_key, message, shared_info_1 \\ <<>>, shared_info_2 \\ <<>>, my_ephemeral_key_pair \\ nil, init_vector \\ nil) do
-    params = Parameters.ecies_aes128_sha256() # TODO: Why?
+    params = Parameters.ecies_aes128_sha256() # Question, is this always the parameters? If not, how do we choose?
     key_len = params.key_len
 
     # First, create a new ephemeral key pair (SEC1 - §5.1.3 - Step 1)
@@ -106,7 +106,7 @@ defmodule ExthCrypto.ECIES do
   """
   @spec decrypt(ExthCrypto.Key.private_key, binary(), binary(), binary()) :: {:ok, Cipher.plaintext} | {:error, String.t}
   def decrypt(my_static_private_key, ecies_encoded_msg, shared_info_1 \\ <<>>, shared_info_2 \\ <<>>) do
-    params = Parameters.ecies_aes128_sha256() # TODO: Why?
+    params = Parameters.ecies_aes128_sha256() # Question, is this always the parameters? If not, how do we choose?
 
     # Get size of key len, block size and hash len, all in bits
     header_size = 1

--- a/lib/hash/fake.ex
+++ b/lib/hash/fake.ex
@@ -22,18 +22,18 @@ defmodule ExthCrypto.Hash.Fake do
   end
 
   @doc """
-  Updates a given Fake mac stream.
+  Updates a given Fake mac stream, which is, do nothing.
 
   ## Examples
 
-      iex> fake_mac = ExthCrypto.Hash.Fake.init_mac()
+      iex> fake_mac = ExthCrypto.Hash.Fake.init_mac("init")
       ...> |> ExthCrypto.Hash.Fake.update_mac("data")
       iex> is_nil(fake_mac)
       false
   """
   @spec update_mac(fake_mac, binary()) :: fake_mac
-  def update_mac({:fake_mac, mac}, data) do
-    {:fake_mac, mac <> data}
+  def update_mac({:fake_mac, mac}, _data) do
+    {:fake_mac, mac}
   end
 
   @doc """
@@ -45,8 +45,7 @@ defmodule ExthCrypto.Hash.Fake do
       iex> ExthCrypto.Hash.Fake.init_mac("abc")
       ...> |> ExthCrypto.Hash.Fake.update_mac("def")
       ...> |> ExthCrypto.Hash.Fake.final_mac()
-      ...> |> ExthCrypto.Math.bin_to_hex
-      "abcdef"
+      "abc"
   """
   @spec final_mac(fake_mac) :: binary()
   def final_mac({:fake_mac, mac}) do

--- a/lib/hash/fake.ex
+++ b/lib/hash/fake.ex
@@ -1,0 +1,56 @@
+defmodule ExthCrypto.Hash.Fake do
+  @moduledoc """
+  Simple fake hash that basically just returns its own input.
+
+  Gasp, that's reversable!
+  """
+
+  @type fake_mac :: {:fake_mac, binary()}
+
+  @doc """
+  Initializes a new Fake mac stream.
+
+  ## Examples
+
+      iex> fake_mac = ExthCrypto.Hash.Fake.init_mac("abc")
+      iex> is_nil(fake_mac)
+      false
+  """
+  @spec init_mac(binary()) :: fake_mac
+  def init_mac(initial) do
+    {:fake_mac, initial}
+  end
+
+  @doc """
+  Updates a given Fake mac stream.
+
+  ## Examples
+
+      iex> fake_mac = ExthCrypto.Hash.Fake.init_mac()
+      ...> |> ExthCrypto.Hash.Fake.update_mac("data")
+      iex> is_nil(fake_mac)
+      false
+  """
+  @spec update_mac(fake_mac, binary()) :: fake_mac
+  def update_mac({:fake_mac, mac}, data) do
+    {:fake_mac, mac <> data}
+  end
+
+  @doc """
+  Finalizes a given Fake mac stream to produce the current
+  hash.
+
+  ## Examples
+
+      iex> ExthCrypto.Hash.Fake.init_mac("abc")
+      ...> |> ExthCrypto.Hash.Fake.update_mac("def")
+      ...> |> ExthCrypto.Hash.Fake.final_mac()
+      ...> |> ExthCrypto.Math.bin_to_hex
+      "abcdef"
+  """
+  @spec final_mac(fake_mac) :: binary()
+  def final_mac({:fake_mac, mac}) do
+    mac
+  end
+
+end

--- a/lib/hash/keccak.ex
+++ b/lib/hash/keccak.ex
@@ -8,6 +8,7 @@ defmodule ExthCrypto.Hash.Keccak do
   """
 
   @type keccak_hash :: ExthCrypto.hash
+  @type keccak_mac :: {atom(), binary()}
 
   @doc """
   Returns the keccak sha256 of a given input.
@@ -28,4 +29,52 @@ defmodule ExthCrypto.Hash.Keccak do
   def kec(data) do
     :keccakf1600.sha3_256(data)
   end
+
+  @doc """
+  Initializes a new Keccak mac stream.
+
+  ## Examples
+
+      iex> keccak_mac = ExthCrypto.Hash.Keccak.init_mac()
+      iex> is_nil(keccak_mac)
+      false
+  """
+  @spec init_mac() :: keccak_mac
+  def init_mac() do
+    :keccakf1600.init(:sha3_256)
+  end
+
+  @doc """
+  Updates a given Keccak mac stream with the given
+  secret and data, returning a new mac stream.
+
+  ## Examples
+
+      iex> keccak_mac = ExthCrypto.Hash.Keccak.init_mac()
+      ...> |> ExthCrypto.Hash.Keccak.update_mac("data")
+      iex> is_nil(keccak_mac)
+      false
+  """
+  @spec update_mac(keccak_mac, binary()) :: keccak_mac
+  def update_mac(mac, data) do
+    :keccakf1600.update(mac, data)
+  end
+
+  @doc """
+  Finalizes a given Keccak mac stream to produce the current
+  hash.
+
+  ## Examples
+
+      iex> ExthCrypto.Hash.Keccak.init_mac()
+      ...> |> ExthCrypto.Hash.Keccak.update_mac("data")
+      ...> |> ExthCrypto.Hash.Keccak.final_mac()
+      ...> |> ExthCrypto.Math.bin_to_hex
+      "8f54f1c2d0eb5771cd5bf67a6689fcd6eed9444d91a39e5ef32a9b4ae5ca14ff"
+  """
+  @spec final_mac(keccak_mac) :: keccak_hash
+  def final_mac(mac) do
+    :keccakf1600.final(mac)
+  end
+
 end

--- a/lib/mac/mac.ex
+++ b/lib/mac/mac.ex
@@ -74,7 +74,7 @@ defmodule ExthCrypto.MAC do
       ...> |> ExthCrypto.MAC.update(" ")
       ...> |> ExthCrypto.MAC.update("knight")
       ...> |> ExthCrypto.MAC.final()
-      "jedi knight"
+      "jedi"
   """
   @spec final(mac_inst) :: binary()
   def final({mac_type, mac}) do

--- a/lib/math/math.ex
+++ b/lib/math/math.ex
@@ -95,4 +95,17 @@ defmodule ExthCrypto.Math do
     :crypto.strong_rand_bytes(nonce_size)
   end
 
+  @doc """
+  Computes the xor between two equal length binaries.
+
+  ## Examples
+
+      iex> ExthCrypto.Math.xor(<<0b10101010>>, <<0b11110000>>)
+      <<0b01011010>>
+  """
+  @spec xor(binary(), binary()) :: binary()
+  def xor(a, b) when byte_size(a) == byte_size(b) do
+    :crypto.exor(a, b)
+  end
+
 end

--- a/lib/signature/signature.ex
+++ b/lib/signature/signature.ex
@@ -59,12 +59,19 @@ defmodule ExthCrypto.Signature do
 
   ## Examples
 
-      iex> {signature, _r, _s, _recovery_id} = ExthCrypto.Signature.sign_digest("12345", ExthCrypto.Test.private_key(:key_a))
-      iex> ExthCrypto.Signature.verify("12345", signature, ExthCrypto.Test.public_key(:key_a))
+      iex> msg = ExthCrypto.Math.nonce(32)
+      iex> {signature, _r, _s, _recovery_id} = ExthCrypto.Signature.sign_digest(msg, ExthCrypto.Test.private_key(:key_a))
+      iex> ExthCrypto.Signature.verify(msg, signature, ExthCrypto.Test.public_key(:key_a))
       true
 
-      iex> {signature, _r, _s, _recovery_id} = ExthCrypto.Signature.sign_digest("12345", ExthCrypto.Test.private_key(:key_a))
-      iex> ExthCrypto.Signature.verify("12345", signature, ExthCrypto.Test.public_key(:key_b))
+      iex> msg = ExthCrypto.Math.nonce(32)
+      iex> {signature, _r, _s, _recovery_id} = ExthCrypto.Signature.sign_digest(msg, ExthCrypto.Test.private_key(:key_a))
+      iex> ExthCrypto.Signature.verify(msg, signature, ExthCrypto.Test.public_key(:key_b))
+      false
+
+      iex> msg = ExthCrypto.Math.nonce(32)
+      iex> {signature, _r, _s, _recovery_id} = ExthCrypto.Signature.sign_digest(msg, ExthCrypto.Test.private_key(:key_a))
+      iex> ExthCrypto.Signature.verify(msg |> Binary.drop(1), signature, ExthCrypto.Test.public_key(:key_a))
       false
   """
   @spec verify(binary(), signature, ExthCrypto.Key.public_key) :: boolean()
@@ -83,8 +90,16 @@ defmodule ExthCrypto.Signature do
 
   ## Examples
 
-      iex> {signature, _r, _s, _recovery_id} = ExthCrypto.Signature.sign_digest("12345", ExthCrypto.Test.private_key(:key_a))
-      iex> ExthCrypto.Signature.recover("12345", signature, 0)
+      iex> msg = ExthCrypto.Math.nonce(32)
+      iex> {signature, _r, _s, recovery_id} = ExthCrypto.Signature.sign_digest(msg, ExthCrypto.Test.private_key(:key_a))
+      iex> ExthCrypto.Signature.recover(msg, signature, recovery_id)
+      {:ok, <<4, 54, 241, 224, 126, 85, 135, 69, 213, 129, 115, 3, 41, 161, 217, 87, 215,
+              159, 64, 17, 167, 128, 113, 172, 232, 46, 34, 145, 136, 72, 160, 207, 161,
+              171, 255, 26, 163, 160, 158, 227, 196, 92, 62, 119, 84, 156, 99, 224, 155,
+              120, 250, 153, 134, 180, 218, 177, 186, 200, 199, 106, 97, 103, 50, 215, 114>>}
+
+      iex> {signature, _r, _s, recovery_id} = ExthCrypto.Signature.sign_digest(msg = ExthCrypto.Math.nonce(32), ExthCrypto.Test.private_key(:key_a))
+      iex> ExthCrypto.Signature.recover(msg, signature, recovery_id)
       {:ok, <<4, 54, 241, 224, 126, 85, 135, 69, 213, 129, 115, 3, 41, 161, 217, 87, 215,
               159, 64, 17, 167, 128, 113, 172, 232, 46, 34, 145, 136, 72, 160, 207, 161,
               171, 255, 26, 163, 160, 158, 227, 196, 92, 62, 119, 84, 156, 99, 224, 155,

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExthCrypto.Mixfile do
 
   def project do
     [app: :exth_crypto,
-     version: "0.1.3",
+     version: "0.1.4",
      elixir: "~> 1.4",
      description: "Exthereum's Crypto Suite.",
       package: [

--- a/test/hash/fake_test.exs
+++ b/test/hash/fake_test.exs
@@ -1,0 +1,5 @@
+defmodule ExthCrypto.Hash.FakeTest do
+  use ExUnit.Case
+  doctest ExthCrypto.Hash.Fake
+
+end


### PR DESCRIPTION
This patch adds streaming modes to both the AES symmetric streaming and to Keccak hashing (for MAC). These are both requirements of the (again, poorly documented) frame encoding in RLPx.