### PR TITLE
Bump libsecp256k1 dep and bump to 0.1.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ by adding `exth_crypto` to your list of dependencies in `mix.exs`:
 
 ```elixir
 def deps do
-  [{:exth_crypto, "~> 0.1.5"}]
+  [{:exth_crypto, "~> 0.1.6"}]
 end
 ```
 

--- a/mix.exs
+++ b/mix.exs
@@ -3,7 +3,7 @@ defmodule ExthCrypto.Mixfile do
 
   def project do
     [app: :exth_crypto,
-     version: "0.1.5",
+     version: "0.1.6",
      elixir: "~> 1.4",
      description: "Exthereum's Crypto Suite.",
       package: [
@@ -35,7 +35,7 @@ defmodule ExthCrypto.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
-      {:libsecp256k1, "~> 0.1.7", app: false},
+      {:libsecp256k1, "~> 0.1.9"},
       {:keccakf1600, "~> 2.0.0", hex: :keccakf1600_orig},
       {:credo, "~> 0.8", only: [:dev, :test], runtime: false},
       {:ex_doc, "~> 0.17", only: :dev, runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -6,7 +6,7 @@
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.19.1", "519bb9c19526ca51d326c060cb1778d4a9056b190086a8c6c115828eaccea6cf", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.7", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
   "keccakf1600": {:hex, :keccakf1600_orig, "2.0.0", "0a7217ddb3ee8220d449bbf7575ec39d4e967099f220a91e3dfca4dbaef91963", [:rebar3], [], "hexpm"},
-  "libsecp256k1": {:hex, :libsecp256k1, "0.1.7", "25fc95202637c2544883f5ffe79eb905d63297bc270c2ab66b8964947dd8fe38", [:make, :mix], [{:mix_erlang_tasks, "0.1.0", [hex: :mix_erlang_tasks, repo: "hexpm", optional: false]}], "hexpm"},
+  "libsecp256k1": {:hex, :libsecp256k1, "0.1.9", "e725f31364cda7b554d56ce2bb976241303dde5ffd1ad59598513297bf1f2af6", [:make, :mix], [{:mix_erlang_tasks, "0.1.0", [hex: :mix_erlang_tasks, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup": {:hex, :makeup, "0.5.1", "966c5c2296da272d42f1de178c1d135e432662eca795d6dc12e5e8787514edf7", [:mix], [{:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "makeup_elixir": {:hex, :makeup_elixir, "0.8.0", "1204a2f5b4f181775a0e456154830524cf2207cf4f9112215c05e0b76e4eca8b", [:mix], [{:makeup, "~> 0.5.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 0.2.2", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
   "mix_erlang_tasks": {:hex, :mix_erlang_tasks, "0.1.0", "36819fec60b80689eb1380938675af215565a89320a9e29c72c70d97512e4649", [:mix], [], "hexpm"},


### PR DESCRIPTION
This patch bumps to the new version of libsecp256k1 which should fix app errors, as well as issues with `git ls-files`.